### PR TITLE
Add admin role

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,6 @@ class User < ApplicationRecord
 
   enum :role, { regular: 1, admin: 5 }, default: :regular
 
-  validates :first_name, :last_name, :username, :role, presence: true
+  validates :first_name, :last_name, :username, presence: true
   validates :username, uniqueness: { case_sensitive: false }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :first_name, :last_name, :username, presence: true
+  enum :role, { regular: 1, admin: 5 }, default: :regular
+
+  validates :first_name, :last_name, :username, :role, presence: true
   validates :username, uniqueness: { case_sensitive: false }
 end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -26,16 +26,25 @@
 
     <!-- Authenticated User -->
     <% if user_signed_in? %>
+      
+      <!-- Admin User -->
+      <% if current_user.admin? %>
+        <span class="px-4 py-1 font-medium text-gray-800 hover:text-gray-400 transition">
+          ADMIN
+        </span>
+      <% end %>
+      <!-- End Admin User -->
+
       <span class="px-4 mr-1 py-1 font-medium text-gray-800 hover:text-gray-400 transition">
         <%= current_user.username.upcase %>
       </span>
 
       <%= outline_button_to(t('.log_out').upcase, destroy_user_session_path, color: 'red', method: :delete) %>
 
-      <!-- Not Authenticated User -->
+    <!-- Not Authenticated User -->
     <% else %>
       <span class="px-4 py-1 font-medium text-gray-800 hover:text-gray-400 transition">
-        TEST
+        GUEST
       </span>
 
       <%= outline_link_to(t('.log_in').upcase, new_user_session_path) %>

--- a/config/locales/models/user/en.yml
+++ b/config/locales/models/user/en.yml
@@ -14,3 +14,6 @@ en:
         password_confirmation: Password Confirmation
         created_at: Created at
         remember_me: Remember me
+        role:
+          regular: Regular
+          admin: Admin

--- a/config/locales/models/user/pt-BR.yml
+++ b/config/locales/models/user/pt-BR.yml
@@ -14,3 +14,6 @@ pt-BR:
         password_confirmation: Confirme a Senha
         created_at: Criado em
         remember_me: Mantenha-me conectado
+        role:
+          regular: Comum
+          admin: Admin

--- a/db/migrate/20250519144606_add_role_to_user.rb
+++ b/db/migrate/20250519144606_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :role, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_15_154218) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_19_144606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -25,6 +25,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_15_154218) do
     t.string "username", null: false
     t.string "last_name", null: false
     t.string "first_name", null: false
+    t.integer "role"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,4 +8,8 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
-User.create!(first_name: 'Master', last_name: 'Admin', username: 'Master', email: 'master@email.com', password: '123456')
+# Admin User
+User.create!(first_name: 'Master', last_name: 'Admin', username: 'Master', email: 'master@email.com', password: '12345678', password_confirmation: '12345678', role: :admin)
+
+#Regular User
+User.create!(first_name: 'User 1', last_name: 'User 1', username: 'User 1', email: 'user1@email.com', password: '12345678', password_confirmation: '12345678', role: :regular)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     sequence(:email) { |n| "test#{n}@email.com" }
     password { 'password123' }
     password_confirmation { 'password123' }
+    role { :regular }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe User, type: :model do
       it { should validate_presence_of(:username) }
       it { should validate_presence_of(:email) }
       it { should validate_presence_of(:password) }
-      it { should validate_presence_of(:role) }
     end
 
     context 'default' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,11 +3,21 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   describe "#valid?" do
     context "presence" do
+      subject { create(:user) }
       it { should validate_presence_of(:first_name) }
       it { should validate_presence_of(:last_name) }
       it { should validate_presence_of(:username) }
       it { should validate_presence_of(:email) }
       it { should validate_presence_of(:password) }
+      it { should validate_presence_of(:role) }
+    end
+
+    context 'default' do
+      it 'new user role default for regular' do
+        user = User.new(first_name: 'abc', last_name: 'abc', username: 'abc', email: 'abc@email.com', password: '12345678', password_confirmation: '12345678')
+
+        expect(user.role).to eq 'regular'
+      end
     end
 
     context 'uniqueness' do
@@ -24,6 +34,7 @@ RSpec.describe User, type: :model do
       subject { create(:user) }
       it { should allow_value('user@example.com').for(:email) }
       it { should_not allow_value('userexample').for(:email) }
+      it { should define_enum_for(:role).with_values(regular: 1, admin: 5) }
     end
   end
 end

--- a/spec/system/user/admin_visit_root_path_spec.rb
+++ b/spec/system/user/admin_visit_root_path_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'Admin visits root path', type: :system do
+  it 'and view navbar Admin validation' do
+    admin = create(:user, role: :admin)
+
+    login_as admin
+    visit root_path
+
+    within 'nav' do
+      expect(page).to have_content 'ADMIN'
+    end
+  end
+end


### PR DESCRIPTION
Added attribute role on model user and its respective tests as an enum, with values regular: 1 and admin: 5

Added seeds for both types of user.


Resolve #25 